### PR TITLE
Add Fedora Support

### DIFF
--- a/MedgingOnLinux.sh
+++ b/MedgingOnLinux.sh
@@ -69,6 +69,21 @@ check_and_install_xdelta3_nix() {
     fi
 }
 
+# Function to check and install xdelta3 on Fedora
+check_and_install_xdelta3_fedora() {
+    xdeltapkg="xdelta"
+    if dnf list --installed | grep -qw "${xdeltapkg}"; then
+        echo -e "${GREEN}${xdeltapkg} is installed${NC}"
+    else
+        if ! sudo dnf install -y "${xdeltapkg}"; then
+            echo "Failed to install ${xdeltapkg}."
+            exit 1
+        else
+            echo -e "${GREEN}${xdeltapkg} is installed${NC}"
+        fi
+    fi
+}
+
 # Check if the OS is Arch Linux
 if [ "$os_name" = "Arch Linux" ]; then
     # Prompt the user to update the system
@@ -104,6 +119,20 @@ fi
 # Check if the OS is NixOS
 if [ "$os_name" = "NixOS" ]; then
     check_and_install_xdelta3_nix
+fi
+
+# Check if the OS is Fedora
+if [ "$os_name" = "Fedora Linux" ] ; then
+    # Prompt the user to update the system
+    read -p "Do you want to update your operating system before continuing? It can prevent errors. (Y/N): " update_choice
+    if [[ "$update_choice" =~ ^[Yy]$ ]]; then
+        echo "Updating your operating system before continuing."
+        if ! sudo dnf upgrade -y; then
+            echo "Failed to update the system."
+            exit 1
+        fi
+    fi
+    check_and_install_xdelta3_fedora
 fi
 
 default_dir="$HOME/.local/share/Steam/steamapps/common/mirrors edge"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ MedgingOnLinux is a script that's designed to help get people speedrunning Mirro
 - Arch Linux (and all derivatives, such as Manjaro or ElementaryOS)
 - Debian/Ubuntu (and all derivatives, such as Linux Mint or Pop_OS!)
 - NixOS
+- Fedora
 
 
 ### Usage


### PR DESCRIPTION
**Changes:**
- Added support for Fedora to the install script
  - Fedora, as far as I can tell, does not have a specific "xdelta3" package, it's simply called "xdelta" 
- Added reference to Fedora in the README

Regardless of if you choose to merge this or not, thank you for making the original script. I'm incredibly happy to be able to use LiveSplit again.